### PR TITLE
Fixes links to pages

### DIFF
--- a/reportwidgets/toppages/partials/_widget.htm
+++ b/reportwidgets/toppages/partials/_widget.htm
@@ -14,15 +14,15 @@
                 <tbody>
                     <?php foreach ($rows as $row): 
                         $percentage = $total > 0 ? round($row[1]/$total*100, 2) : 0;
-                        $url = URL::to($row[0]);
+                        $url = $row[0];
                     ?>
                         <tr>
-                            <td><a href="<?= $url ?>"><?= e($row[0]) ?></a></td>
-                            <td><a href="<?= $url ?>"><?= e($row[1]) ?></a></td>
+                            <td><a href="<?= $url ?>" target="_blank"><?= e($row[0]) ?></a></td>
+                            <td><a href="<?= $url ?>" target="_blank"><?= e($row[1]) ?></a></td>
                             <td>
                                 <div class="progress">
                                     <div class="bar" style="width: <?= $percentage.'%' ?>"></div>
-                                    <a href="<?= $url ?>"><?= $percentage.'%' ?></a>
+                                    <a href="<?= $url ?>" target="_blank"><?= $percentage.'%' ?></a>
                                 </div>
                             </td>
                         </tr>


### PR DESCRIPTION
If october is installed in a subdirectory, URL::to() fails as it prepends the subpath as well. However, in this case the path inclduding the path to the installation is already included in the url returned by Google. This leads to incorrect generate links by this function.
