### PR TITLE
Fixed getting temporary path on L5 (and keep backward compatibility for L4)

### DIFF
--- a/classes/Analytics.php
+++ b/classes/Analytics.php
@@ -35,12 +35,7 @@ class Analytics
         if (!$settings->gapi_key)
             throw new ApplicationException('Google Analytics API private key is not uploaded. Please configure Google Analytics access on the System / Settings / Google Analytics page.');
 
-        $tempDirectory = '/Google_Client';
-        if (function_exists('temp_path')) {
-            $tmpDir = temp_path() . $tempDirectory;
-        } else {
-            $tmpDir = Config::get('cms.tempDir', sys_get_temp_dir()) . $tempDirectory;
-        }
+        $tmpDir = temp_path() . '/Google_Client';
 
         $this->client = new Google_Client();
         $this->client->setApplicationName($settings->project_name);

--- a/classes/Analytics.php
+++ b/classes/Analytics.php
@@ -35,7 +35,12 @@ class Analytics
         if (!$settings->gapi_key)
             throw new ApplicationException('Google Analytics API private key is not uploaded. Please configure Google Analytics access on the System / Settings / Google Analytics page.');
 
-        $tmpDir = Config::get('cms.tempDir', sys_get_temp_dir()) . '/Google_Client';
+        $tempDirectory = '/Google_Client';
+        if (function_exists('temp_path')) {
+            $tmpDir = temp_path() . $tempDirectory;
+        } else {
+            $tmpDir = Config::get('cms.tempDir', sys_get_temp_dir()) . $tempDirectory;
+        }
 
         $this->client = new Google_Client();
         $this->client->setApplicationName($settings->project_name);


### PR DESCRIPTION
In L5 version of OctoberCMS, there is no config key cms.tempDir and it throws "open_basedir restriction in effect" warning.