### PR TITLE
Add option to anonymize visitor IP

### DIFF
--- a/components/Tracker.php
+++ b/components/Tracker.php
@@ -23,4 +23,9 @@ class Tracker extends ComponentBase
     {
         return Settings::get('domain_name');
     }
+
+    public function anonymizeIp()
+    {
+        return Settings::get('anonymize_ip');
+    }
 }

--- a/components/tracker/default.htm
+++ b/components/tracker/default.htm
@@ -5,6 +5,9 @@
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
   ga('create', '{{ __SELF__.trackingId }}', '{{ __SELF__.domainName }}');
+{% if __SELF__.anonymizeIp %}
+  ga('set', 'anonymizeIp', true);
+{% endif %}
   ga('send', 'pageview');
 
 </script>

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -49,6 +49,7 @@ return [
         'profile_id'           => 'Analytics View/Profile ID number',
         'gapi_key'             => 'Private key',
         'tracking_id'          => 'Tracking ID',
+        'anonymize_ip'         => 'Anonymize IP',
         'domain_name'          => 'Domain name',
         'project_name_comment' => 'The name you assigned to the project when created in Google API Console',
         'client_id_comment'    => 'You can find the Client ID on the project page in Google API Console',
@@ -56,6 +57,7 @@ return [
         'profile_id_comment'   => 'You can find it on the Google Analytics Admin / View Settings page',
         'gapi_key_comment'     => 'The private key file you downloaded from Google API Console',
         'tracking_id_comment'  => 'You can find the Tracking ID on the Admin / Property Settings page',
+        'anonymize_ip_comment' => 'Activate the IP anonymization for visitors',
         'domain_name_comment'  => 'Specify the domain name you are going to track',
     ],
 ];

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -34,5 +34,6 @@ class Settings extends Model
     public function initSettingsData()
     {
         $this->domain_name = 'auto';
+        $this->anonymize_ip = false;
     }
 }

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -25,3 +25,10 @@ tabs:
             span: right
             label: rainlab.googleanalytics::lang.settings.domain_name
             commentAbove: rainlab.googleanalytics::lang.settings.domain_name_comment
+
+        anonymize_ip:
+            tab: rainlab.googleanalytics::lang.strings.tracking
+            type: switch
+            span: left
+            label: rainlab.googleanalytics::lang.settings.anonymize_ip
+            commentAbove: rainlab.googleanalytics::lang.settings.anonymize_ip_comment


### PR DESCRIPTION
I have set the initSetting for anonymization to false. Since the SettingsModel gives `null` in case of non existing fields, this should be backwards compatible.