### PR TITLE
Remove irritating error on empty traffic overview chart

### DIFF
--- a/reportwidgets/TrafficOverview.php
+++ b/reportwidgets/TrafficOverview.php
@@ -64,7 +64,7 @@ class TrafficOverview extends ReportWidgetBase
         );
         
         $rows = $data->getRows();
-        if (!$rows) {
+        if (!$rows)
             throw new ApplicationException('No traffic found yet.');
 
         $points = [];

--- a/reportwidgets/TrafficOverview.php
+++ b/reportwidgets/TrafficOverview.php
@@ -62,15 +62,20 @@ class TrafficOverview extends ReportWidgetBase
             'ga:visits',
             ['dimensions' => 'ga:date']
         );
+        
+        $rows = $data->getRows();
+        if (!$rows) {
+            throw new ApplicationException('No traffic found yet.');
+
         $points = [];
-        foreach ($data->getRows() as $row) {
+        foreach ($rows as $row) {
             $point = [
                 strtotime($row[0])*1000,
                 $row[1]
             ];
 
             $points[] = $point;
-        }
+        }            
 
         $this->vars['rows'] = str_replace('"', '', substr(substr(json_encode($points), 1), 0, -1));
     }


### PR DESCRIPTION
The traffic overview chart shows "Invalid argument supplied for foreach()" if there was no traffic yet since the rows are returned as NULL. This fixes it.