### PR TITLE
Update 'google/apiclient' to ^2.4 to sort PHP 7.4 issue with 'implode…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
     "require": {
         "php": ">=7.0",
         "guzzlehttp/guzzle": "~6.0",
-        "google/apiclient": "^2.0.0"
+        "google/apiclient": "^2.4"
     }
 }

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -11,3 +11,4 @@
 1.2.2: Improve translations, bump version requirement to PHP 7
 1.2.3: Added a switch for forceSSL
 1.2.4: Added permission for dashboard widgets. Added Turkish, Spanish and Estonian translations.
+1.2.5: Fixed issues with PHP 7.4 compatibility.


### PR DESCRIPTION
I have tested this dependancies update on PHP 7.4.4, PHP 7.3.16 and PHP 7.2.29 in relation to issue https://github.com/rainlab/googleanalytics-plugin/issues/93.

> NOTE: It has not been tested with PHP 7.0 and PHP 7.1.