### PR TITLE
Upgraded tracker code to Universal Analytics (gtag.js)

### DIFF
--- a/components/tracker/default.htm
+++ b/components/tracker/default.htm
@@ -1,11 +1,16 @@
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ __SELF__.trackingId }}"></script>
 <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-    ga('create', '{{ __SELF__.trackingId }}', '{{ __SELF__.domainName }}');
-    {% if __SELF__.forceSSL %}ga('set', 'forceSSL', true);{% endif %}
-    {% if __SELF__.anonymizeIp %}ga('set', 'anonymizeIp', true);{% endif %}
-    ga('send', 'pageview');
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+{% if __SELF__.domainName %}
+    gtag('set', { 'cookie_domain': '{{ __SELF__.domainName }}' });
+{% endif %}
+{% if __SELF__.forceSSL %}
+    gtag('set', { 'force_ssl': true });
+{% endif %}
+{% if __SELF__.anonymizeIp %}
+    gtag('set', { 'anonymize_ip': true });
+{% endif %}
+    gtag('config', '{{ __SELF__.trackingId }}');
 </script>

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -12,3 +12,4 @@
 1.2.3: Added a switch for forceSSL
 1.2.4: Added permission for dashboard widgets. Added Turkish, Spanish and Estonian translations.
 1.2.5: Fixed issues with PHP 7.4 compatibility.
+1.3.0: !!! Upgraded tracker code to Universal Analytics (gtag.js)


### PR DESCRIPTION
Global site tag tracker is the new default for Google Analytics. Plugin settings are compatible with new tracker parameters (not sure if forceSSL is relevant anymore).

It will be eventually upgraded with Consent Mode: https://blog.google/products/marketingplatform/360/measure-conversions-while-respecting-user-consent-choices/